### PR TITLE
Update eslint to 0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "Adametry",
   "license": "MIT",
   "dependencies": {
-    "eslint": "^0.10.0",
+    "eslint": "0.x",
     "gulp-util": "^3.0.1",
     "map-stream": "^0.1.0",
     "through": "^2.3.4"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "Adametry",
   "license": "MIT",
   "dependencies": {
-    "eslint": "^0.9.2",
+    "eslint": "^0.10.0",
     "gulp-util": "^3.0.1",
     "map-stream": "^0.1.0",
     "through": "^2.3.4"


### PR DESCRIPTION
Since eslint uses pre-release major versioning, `^0.9.2` does not treat `0.10.0` as a compatible version