### PR TITLE
Fix to option migration - prevents reduce error in eslint

### DIFF
--- a/util.js
+++ b/util.js
@@ -62,7 +62,7 @@ exports.migrateOptions = function migrateOptions(options) {
 	}
 
 	options.envs = options.envs || options.env;
-	if (options.envs != null && Array.isArray(options.envs)) {
+	if (options.envs != null && !Array.isArray(options.envs)) {
 		options.envs = Object.keys(options.envs).filter(function cliEnv(key) {
 			return options.envs[key];
 		});


### PR DESCRIPTION
This fix repairs a problem with the options migration in the 0.4.1 release,
where a negation was missing for handling `options.env`. The downside of
this is that all passages through gulp-eslint would fail when eslint tries
to reduce its total collection of env options during configuration.

I couldn't find a good place to put a test for this, as it seems the entire
options migration doesn't have tests yet. However, this helps unblock people
who are on `^0.4.0`. This bug does not happen in 0.4.0.