### PR TITLE
Update ESLint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "bufferstreams": "1.0.1",
-    "eslint": "^0.17.0",
+    "eslint": "^0.17.1",
     "gulp-util": "^3.0.4",
     "object-assign": "^2.0.0",
     "optional": "^0.1.3",


### PR DESCRIPTION
A new version of ESLint was just released that contains some important ES6 bug fixes. I would very much appreciate if you could merge this commit and release a new gulp-eslint version.

Thanks!