### PR TITLE
Adds support for --quiet option

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ function gulpEslint(options) {
 		var config = linter.getConfigForFile(filePath);
 		util.loadPlugins(config.plugins);
 		var messages = eslint.verify(str, config, filePath);
+		if (options.quiet) {
+			messages = messages.filter(function isError(message) {
+				return message.severity === 2;
+			});
+		}
 		//eslint.reset();
 		return {
 			filePath: filePath,


### PR DESCRIPTION
The command line interface of ESLint supports --quiet to only report errors and ignore warnings. The ESLint CLIEngine do not expose this option because _[quiet only has to do with output and CLIEngine is designed specifically to not output anything](https://github.com/eslint/eslint/issues/1768#issuecomment-73069268)_.

This is is useful when you lint something where warnings don't matter e.g. a git pre-commit hook. It can be confusing to see a lot of warnings and still see the commit run.

Let me know if there is a better place or a better way to do this =)