### PR TITLE
Add support for globally install eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var PluginError = require('gulp-util').PluginError;
 var eslint = require('eslint').linter;
 var CLIEngine = require('eslint').CLIEngine;
 var util = require('./util');
+var resolve = require('resolve').sync
+var execSync = require('child_process').execSync;
+var path = require('path');
 
 /**
  * Append eslint result to each file
@@ -47,6 +50,40 @@ function gulpEslint(options) {
 	});
 
 }
+
+/**
+ * Use globally installed eshint
+ */
+gulpEslint.useGlobalModules = function() {
+	try {
+		var globalModulesPath = execSync('npm config get prefix').toString().trim();
+		globalModulesPath = path.join(globalModulesPath, 'lib', 'node_modules');
+
+		var globalEslintPath = resolve('eslint', {
+			basedir: globalModulesPath
+		});
+
+		var globalIgnoredPathsPath = resolve('eslint/lib/ignored-paths', {
+			basedir: globalModulesPath
+		});
+
+		var globalFileFinderPath = resolve('eslint/lib/file-finder', {
+			basedir: globalModulesPath
+		});
+
+		var globalEslint = require(globalEslintPath);
+
+		eslint = globalEslint.linter;
+		CLIEngine = globalEslint.CLIEngine;
+
+		util.useGlobalModules(
+			CLIEngine,
+			require(globalIgnoredPathsPath),
+			require(globalFileFinderPath)
+		);
+	} catch (err) {
+	}
+};
 
 /**
  * Fail when an eslint error is found in eslint results.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint": "^0.20.0",
     "gulp-util": "^3.0.4",
     "object-assign": "^2.0.0",
+    "resolve": "^1.1.6",
     "through2": "^0.6.3"
   },
   "devDependencies": {

--- a/util.js
+++ b/util.js
@@ -7,7 +7,14 @@ var path = require('path'),
 	IgnoredPaths = require('eslint/lib/ignored-paths'),
 	FileFinder = require('eslint/lib/file-finder');
 
-var ignoreFileFinder = new FileFinder('.eslintignore');
+/**
+ * Use globally installed eshint
+ */
+exports.useGlobalModules = function(CLIEngine_, IgnoredPaths_, FileFinder_) {
+	CLIEngine = CLIEngine_;
+	IgnoredPaths = IgnoredPaths_;
+	FileFinder = FileFinder_;
+};
 
 /**
  * Mimic the CLIEngine.isPathIgnored,
@@ -15,6 +22,8 @@ var ignoreFileFinder = new FileFinder('.eslintignore');
  */
 exports.isPathIgnored = function(file, options) {
 	var filePath;
+	var ignoreFileFinder = new FileFinder('.eslintignore');
+
 	if (!options.ignore) {
 		return false;
 	}


### PR DESCRIPTION
This allows for the user to install and use different parsers and plugins with ease.

IE now using `babel-eslint` is as simple as `npm install -g babel-eslint`, as opposed to finding where `eslint` is installed in their project and trying to install them there.

Call the function before running any streams.

```javascript
var eslint = require('gulp-eslint');
eslint.useGlobalModules();

gulp.task('example', function () {
  return gulp
    .src('**/*.js')
    .pipe(eslint());
});
```