### PR TITLE
set eslint version to 0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "bufferstreams": "1.0.1",
-    "eslint": "^0.20.0",
+    "eslint": "0.x",
     "gulp-util": "^3.0.4",
     "object-assign": "^2.0.0",
     "through2": "^0.6.3"


### PR DESCRIPTION
Thanks to semantic versioning it is save to assume that eslint API will not break the gulp-eslint build. Basing on eslint changelog https://github.com/eslint/eslint/blob/master/CHANGELOG.md the project seems trustworthy and responsible about this. This way gulp-eslint will always use the latest version of eslint.