### PR TITLE
Move eslint to peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
   ],
   "dependencies": {
     "bufferstreams": "1.0.1",
-    "eslint": "^0.22.1",
     "gulp-util": "^3.0.4",
     "object-assign": "^3.0.0"
+  },
+  "peerDependencies": {
+    "eslint": "^0.22.1"
   },
   "devDependencies": {
     "babel-eslint": "^3.0.1",


### PR DESCRIPTION
eslint plugins can define eslint as a peer dependency so that npm can ensure that they are compatible with the installed version of eslint (and warn if they are not). Nesting eslint under gulp-eslint prevents npm checking peer dependency versions - instead another copy of eslint is installed that may be a different version. The end result is that plugins could be run with an incompatible version of eslint and cause errors.

Changing eslint to a peer dependency means that the plugins and gulp-eslint will use the same copy of eslint, so any incompatibilities will be flagged by npm before they can lead to errors.

Fixes #68 