### PR TITLE
recommend failAfterError

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ gulp.task('lint', function () {
         // Alternatively use eslint.formatEach() (see Docs).
         .pipe(eslint.format())
         // To have the process exit with an error code (1) on
-        // lint error, return the stream and pipe to failOnError last.
-        .pipe(eslint.failOnError());
+        // lint error, return the stream and pipe to failAfterError last.
+        .pipe(eslint.failAfterError());
 });
 
 gulp.task('default', ['lint'], function () {


### PR DESCRIPTION
This is a much better default as most people will want to see all the errors in their console, not just the first.

Closes #97