### PR TITLE
Add ability to fail lint if too many warnings found, fixes #100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0
+
+* Bump eslint dependency to ^1.0.0
+* Update dev-dependencies and js-doc formats
+
 ## 0.15.0
 
 * Update dependencies

--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ gulp.src('**/*.js')
 	.pipe(eslint.failAfterError())
 	.pipe(gulp.dest('../output'));
 ```
+### eslint.failOnWarning(maxWarnings)
+
+Stop a task/stream if too many warnings have been reported.
+
+```javascript
+// Cause the stream to stop(/fail) when the stream ends if too many warnings occurred.
+gulp.src('**/*.js')
+	.pipe(eslint())
+	.pipe(eslint.failOnWarnings(100))
+	.pipe(gulp.dest('../output'));
+```
 
 ### eslint.format(formatter, output)
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ gulp.src('**/*.js')
 	.pipe(eslint.failAfterError())
 	.pipe(gulp.dest('../output'));
 ```
-### eslint.failOnWarning(maxWarnings)
+### eslint.failAfterWarnings(maxWarnings)
 
 Stop a task/stream if too many warnings have been reported.
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function gulpEslint(options) {
  * @returns {stream} gulp file stream
  */
 gulpEslint.failOnError = function() {
+
 	return util.transform(function(file, enc, output) {
 		var messages = file.eslint && file.eslint.messages || [],
 			error = null;

--- a/test/fail.js
+++ b/test/fail.js
@@ -50,6 +50,42 @@ describe('gulp-eslint failOnError', function() {
 		}));
 	});
 
+	it('should pass a file if warnings are under threshold', function(done) {
+
+		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
+
+		lintStream.pipe(eslint.failOnError({maxWarnings: 3}))
+		.on('error', done)
+		.on('finish', done);
+
+		lintStream.end(new File({
+			path: 'test/fixtures/invalid.js',
+			contents: new Buffer('x = 0; y = 0;')
+		}));
+	});
+
+	it('should fail immediately if too many warnings when using failOnError', function(done) {
+
+		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
+
+		lintStream.pipe(eslint.failOnError({maxWarnings: 2}))
+		.on('error', function(err) {
+			should.exist(err);
+			err.name.should.equal('ESLintError');
+			err.message.should.equal('Failed because of too many warnings. ' +
+										'Found 2 warnings, threshold is 2.');
+			done();
+		})
+		.on('end', function() {
+			done(new Error('An error was not thrown before ending'));
+		});
+
+		lintStream.end(new File({
+			path: 'test/fixtures/invalid.js',
+			contents: new Buffer('x = 0; y = 0;')
+		}));
+	});
+
 	it('should fail when the file stream ends if an error is found', function(done) {
 		var lintStream = eslint({
 			envs: ['browser'],
@@ -106,6 +142,43 @@ describe('gulp-eslint failOnError', function() {
 		lintStream.end(new File({
 			path: 'test/fixtures/invalid.js',
 			contents: new Buffer('x = 0;')
+		}));
+	});
+
+	it('should pass when the file stream ends if too few warnings found', function(done) {
+		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
+
+		lintStream.pipe(eslint.failAfterError({maxWarnings: 3}))
+		.on('error', done)
+		.on('finish', done);
+
+		lintStream.end(new File({
+			path: 'test/fixtures/invalid.js',
+			contents: new Buffer('x = 0; y = 0;')
+		}));
+	});
+
+	it('should fail when the file stream ends if too many warnings are found', function(done) {
+		var lintStream = eslint({
+			envs: ['browser'],
+			rules: {
+				'no-undef': 1,
+				'strict': 0
+			}
+		});
+
+		lintStream.pipe(eslint.failAfterError({maxWarnings: 1}).on('error', function(err) {
+			should.exists(err);
+			err.message.should.equal('Failed because of too many warnings. ' +
+										'Found 2 warnings, threshold is 1.');
+			err.name.should.equal('ESLintError');
+			err.plugin.should.equal('gulp-eslint');
+			done();
+		}));
+
+		lintStream.end(new File({
+			path: 'test/fixtures/invalid.js',
+			contents: new Buffer('x = 0; y = 0;')
 		}));
 	});
 

--- a/test/fail.js
+++ b/test/fail.js
@@ -50,20 +50,6 @@ describe('gulp-eslint failOnError', function() {
 		}));
 	});
 
-	it('should pass a file if warnings are under threshold', function(done) {
-
-		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
-
-		lintStream.pipe(eslint.failOnError({maxWarnings: 3}))
-		.on('error', done)
-		.on('finish', done);
-
-		lintStream.end(new File({
-			path: 'test/fixtures/invalid.js',
-			contents: new Buffer('x = 0; y = 0;')
-		}));
-	});
-
 	it('should fail when the file stream ends if an error is found', function(done) {
 		var lintStream = eslint({
 			envs: ['browser'],

--- a/test/fail.js
+++ b/test/fail.js
@@ -64,28 +64,6 @@ describe('gulp-eslint failOnError', function() {
 		}));
 	});
 
-	it('should fail immediately if too many warnings when using failOnError', function(done) {
-
-		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
-
-		lintStream.pipe(eslint.failOnError({maxWarnings: 2}))
-		.on('error', function(err) {
-			should.exist(err);
-			err.name.should.equal('ESLintError');
-			err.message.should.equal('Failed because of too many warnings. ' +
-										'Found 2 warnings, threshold is 2.');
-			done();
-		})
-		.on('end', function() {
-			done(new Error('An error was not thrown before ending'));
-		});
-
-		lintStream.end(new File({
-			path: 'test/fixtures/invalid.js',
-			contents: new Buffer('x = 0; y = 0;')
-		}));
-	});
-
 	it('should fail when the file stream ends if an error is found', function(done) {
 		var lintStream = eslint({
 			envs: ['browser'],
@@ -145,10 +123,26 @@ describe('gulp-eslint failOnError', function() {
 		}));
 	});
 
+	it('should handle eslint reports without messages', function(done) {
+		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
+
+		lintStream.pipe(eslint.failAfterError())
+		.on('error', done)
+		.on('finish', done);
+
+		lintStream.end(new File({
+			path: 'test/fixtures/invalid.js',
+			contents: new Buffer('x = 0;')
+		}));
+	});
+
+});
+
+describe('gulp-eslint failAfterWarnings', function() {
 	it('should pass when the file stream ends if too few warnings found', function(done) {
 		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
 
-		lintStream.pipe(eslint.failAfterError({maxWarnings: 3}))
+		lintStream.pipe(eslint.failAfterWarnings(3))
 		.on('error', done)
 		.on('finish', done);
 
@@ -167,7 +161,7 @@ describe('gulp-eslint failOnError', function() {
 			}
 		});
 
-		lintStream.pipe(eslint.failAfterError({maxWarnings: 1}).on('error', function(err) {
+		lintStream.pipe(eslint.failAfterWarnings(1).on('error', function(err) {
 			should.exists(err);
 			err.message.should.equal('Failed because of too many warnings. ' +
 										'Found 2 warnings, threshold is 1.');
@@ -179,19 +173,6 @@ describe('gulp-eslint failOnError', function() {
 		lintStream.end(new File({
 			path: 'test/fixtures/invalid.js',
 			contents: new Buffer('x = 0; y = 0;')
-		}));
-	});
-
-	it('should handle eslint reports without messages', function(done) {
-		var lintStream = eslint({rules: {'no-undef': 1, 'strict': 0}});
-
-		lintStream.pipe(eslint.failAfterError())
-		.on('error', done)
-		.on('finish', done);
-
-		lintStream.end(new File({
-			path: 'test/fixtures/invalid.js',
-			contents: new Buffer('x = 0;')
 		}));
 	});
 

--- a/test/util.js
+++ b/test/util.js
@@ -237,6 +237,28 @@ describe('utility methods', function() {
 
 	});
 
+	describe('isWarningMessage', function() {
+
+		it('should consider severity 1 a warning', function() {
+			var message = {
+				severity: 1
+			};
+			var isWarning = util.isWarningMessage(message);
+			isWarning.should.equal(true);
+
+		});
+
+		it('should determine severity from an config array', function() {
+			var message = {
+				severity: [1]
+			};
+			var isWarning = util.isWarningMessage(message);
+			isWarning.should.equal(true);
+
+		});
+
+	});
+
 	describe('resolveFormatter', function() {
 
 		it('should default to the "stylish" formatter', function() {

--- a/util.js
+++ b/util.js
@@ -123,6 +123,20 @@ exports.isErrorMessage = function(message) {
 };
 
 /**
+ * Is the message a warning?
+ *
+ * @param {Object} message - an eslint message
+ * @returns {Boolean} whether the message is an warning message
+ */
+exports.isWarningMessage = function(message) {
+	var level = message.fatal ? 2 : message.severity;
+	if (Array.isArray(level)) {
+		level = level[0];
+	}
+	return (level === 1);
+};
+
+/**
  * Resolve formatter from unknown type (accepts string or function)
  *
  * @throws TypeError thrown if unable to resolve the formatter type


### PR DESCRIPTION
Took a stab at solving my own problem as reported in https://github.com/adametry/gulp-eslint/issues/100

It looks like eslint's `--max-warnings` flag only operates when running in CLI mode and isn't directly supported in `CLIEngine`.  I recreated some of the basic logic in a new `failAfterWarnings(maxWarnings)` pipeable function.  
