### PR TITLE
add link to ESLint CLIEngine docs, clarify use of `envs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For additional examples, look through the [example directory](https://github.com
 *No explicit configuration.* A `.eslintrc` file may be resolved relative to each linted file.
 
 ### eslint(options)
+See [ESlint CLIEngine options](http://eslint.org/docs/developer-guide/nodejs-api#cliengine).
 
 #### options.rules
 
@@ -130,6 +131,8 @@ Specify a list of [environments](http://eslint.org/docs/user-guide/configuring#s
 Type: `Object`
 
 Specify [environments](http://eslint.org/docs/user-guide/configuring#specifying-environments). Each key must match an existing env definition, and the key determines whether the env’s rules are applied (`true`) or not (`false`).
+
+Note that setting an env to `false` will not override an env that is set to `true` in the _.eslintrc_ being extended.
 
 Alias: `env` *(deprecated)*
 
@@ -265,7 +268,7 @@ eslint.format();
 
 // write messages to stdout
 eslint.format('junit', process.stdout)
-``` 
+```
 
 ### eslint.formatEach(formatter, output)
 
@@ -286,7 +289,7 @@ ESLint will also detect an `.eslintignore` file at the cwd or a parent directory
 
 ## Extensions
 
-ESLint results are attached as an "eslint" property to the vinyl files that pass through a Gulp.js stream pipeline. This is available to streams that follow the initial `eslint` stream. The [eslint.result](#result) and [eslint.results](#results) methods are made available to support extensions and custom handling of ESLint results. 
+ESLint results are attached as an "eslint" property to the vinyl files that pass through a Gulp.js stream pipeline. This is available to streams that follow the initial `eslint` stream. The [eslint.result](#result) and [eslint.results](#results) methods are made available to support extensions and custom handling of ESLint results.
 
 #### Gulp-Eslint Extensions:
 * [gulp-eslint-threshold](https://github.com/krmbkt/gulp-eslint-threshold)


### PR DESCRIPTION
Thank you for creating and maintaining this very useful plugin!

I ran into some issues trying to get the `envs` options to work, and think that these additions will help clarify what is actually going on. Hopefully it will save someone else some time.