### PR TITLE
feat: add isFixed method

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ Format each linted file individually. This should be used in the stream after pi
 
 The arguments for `formatEach` are the same as the arguments for `format`.
 
+### eslint.isFixed(file)
+
+Helper method that returns true if current file has `eslint` property, and also has the `eslint.fixed` property. Usable particularly with `gulp-if`, like so:
+
+```javascript
+.pipe(gulpIf(eslint.isFixed, gulp.dest('some-dest')));
+```
 
 ##Configuration
 

--- a/example/fix.js
+++ b/example/fix.js
@@ -6,11 +6,6 @@ var gulp = require('gulp');
 var gulpIf = require('gulp-if');
 var eslint = require('../');
 
-function isFixed(file) {
-	// Has ESLint fixed the file contents?
-	return file.eslint != null && file.eslint.fixed;
-}
-
 gulp.task('lint-n-fix', function() {
 
 	return gulp.src('../test/fixtures/*.js')
@@ -19,7 +14,7 @@ gulp.task('lint-n-fix', function() {
 		}))
 		.pipe(eslint.format())
 		// if fixed, write the file to dest
-		.pipe(gulpIf(isFixed, gulp.dest('../test/fixtures')));
+		.pipe(gulpIf(eslint.isFixed, gulp.dest('../test/fixtures')));
 });
 
 gulp.task('flag-n-fix', function() {
@@ -33,7 +28,7 @@ gulp.task('flag-n-fix', function() {
 		}))
 		.pipe(eslint.format())
 		// if fixed, write the file to dest
-		.pipe(gulpIf(isFixed, gulp.dest('../test/fixtures')));
+		.pipe(gulpIf(eslint.isFixed, gulp.dest('../test/fixtures')));
 });
 
 gulp.task('default', ['lint-n-fix']);

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ gulpEslint.formatEach = function(formatter, writable) {
  * Wait until all files have been linted and format all results at once.
  *
  * @param {(String|Function)} [formatter=stylish] - The name or function for a ESLint result formatter
- * @param {(Function|stream)} [writable=gulp-util.log] - A funtion or stream to write the formatted ESLint results.
+ * @param {(Function|stream)} [writable=gulp-util.log] - A function or stream to write the formatted ESLint results.
  * @returns {stream} gulp file stream
  */
 gulpEslint.format = function(formatter, writable) {
@@ -200,6 +200,15 @@ gulpEslint.format = function(formatter, writable) {
 			util.writeResults(results, formatter, writable);
 		}
 	});
+};
+
+/**
+ * Utility method to test if file has been fixed by eslint
+ *
+ * @param {file} file - A streamed file instance
+ */
+gulpEslint.isFixed = gulpEslint.fixed = function(file) {
+	return file.eslint !== null && file.eslint.fixed;
 };
 
 module.exports = gulpEslint;

--- a/package.json
+++ b/package.json
@@ -48,14 +48,12 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.0.5",
+    "estraverse-fb": "^1.3.1",
     "gulp": "^3.9.0",
     "istanbul": "^0.4.0",
     "istanbul-coveralls": "^1.0.3",
     "mocha": "^2.2.5",
     "should": "^8.0.1",
     "vinyl": "^1.0.0"
-  },
-  "optionaDependencies": {
-    "estraverse-fb": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "mocha": "^2.2.5",
     "should": "^8.0.1",
     "vinyl": "^1.0.0"
+  },
+  "optionaDependencies": {
+    "estraverse-fb": "^1.3.1"
   }
 }


### PR DESCRIPTION
Added an isFixed (aliased as `fixed`, as well) method to the `gulp-eslint` instance.

Code from #122

Tests pass, although I did have to install `estraverse-fb` to get some of tests to pass, so I've added that as an optional dependency.