### PR TITLE
Correct eslint-path-formatter usage within README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ eslint.format('checkstyle')
 
 // use the "eslint-path-formatter" module formatter
 // (@see https://github.com/Bartvds/eslint-path-formatter)
-eslint.format('eslint-path-formatter')
+eslint.format('node_modules/eslint-path-formatter')
 ```
 
 The `output` argument may be a `WritableStream`, `Function`, or `undefined`. As a `WritableStream`, the formatter results will be written to the stream. If `undefined`, the formatter results will be written to [gulp’s log](https://github.com/gulpjs/gulp-util#logmsg). A `Function` will be called with the formatter results as the only parameter.


### PR DESCRIPTION
As stated in https://github.com/Bartvds/eslint-path-formatter/issues/2 the correct usage of the `eslint-path-formatter` plugin is `.pipe(eslint.format('node_modules/eslint-path-formatter'));`.