### PR TITLE
Add a extension `gulp-reporter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,4 @@ ESLint results are attached as an "eslint" property to the vinyl files that pass
 
 * [gulp-eslint-if-fixed](https://github.com/lukeapage/gulp-eslint-if-fixed)
 * [gulp-eslint-threshold](https://github.com/krmbkt/gulp-eslint-threshold)
+* [gulp-reporter](https://github.com/gucong3000/gulp-reporter)


### PR DESCRIPTION
[gulp-reporter](https://github.com/gucong3000/gulp-reporter) used in team project, it fails only when error belongs to the current author of git.