### PR TITLE
Convert options.rulePaths from string to array to prevent eslint exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Specify a list of [environments](https://eslint.org/docs/user-guide/configuring#
 
 #### options.rulePaths
 
-Type: `Array`
+Type: `Array | String`
 
 This option allows you to specify additional directories from which to load rules files. This is useful when you have custom rules that aren't suitable for being bundled with ESLint. This option works much like the ESLint CLI's [rulesdir option](https://eslint.org/docs/user-guide/command-line-interface#rulesdir).
 

--- a/test/util.js
+++ b/test/util.js
@@ -111,6 +111,11 @@ describe('utility methods', () => {
 			should.exist(options.configFile);
 			options.configFile.should.equal('Config/Path');
 		});
+
+		it('should convert a string value of "rulePaths" to array', () => {
+			const options = util.migrateOptions({rulePaths: "rules"});
+			options.rulePaths.should.be.instanceOf(Array).and.have.length(1);
+		});
 	});
 
 	describe('isErrorMessage', () => {

--- a/util.js
+++ b/util.js
@@ -63,6 +63,10 @@ exports.migrateOptions = function migrateOptions(options) {
 		};
 	}
 
+	if (options && typeof options.rulePaths === "string") {
+		options.rulePaths = [options.rulePaths];
+	}
+
 	return options;
 };
 


### PR DESCRIPTION
**How to reproduce**

Create a `gulpfile.js`:

```
const gulp = require("gulp");
const eslint = require("gulp-eslint");

gulp.task("lint", () => {
  return gulp.src(["tests/spec/**/*.js"])
    .pipe(eslint({
      rulePaths: "rules"
    }))
    .pipe(eslint.format())
    .pipe(eslint.failAfterError());
});

gulp.task("watch", ["lint"], () => {
  gulp.watch("rules/*.js", ["lint"]);
});
```

Will result in

```
TypeError: this.options.rulePaths.forEach is not a function
    at new CLIEngine (/Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/node_modules/eslint/lib/cli-engine.js:407:36)
    at gulpEslint (/Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/node_modules/gulp-eslint/index.js:16:17)
    at Gulp.gulp.task (/Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/gulpfile.js:6:11)
    at module.exports (/Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (/Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/node_modules/orchestrator/index.js:134:8)
    at /Users/sghita/webserver/www/personal/eslint-plugin-jquery-upgrade/node_modules/gulp/bin/gulp.js:129:20
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

**Why?**

It's better to auto-convert and don't bug the user about this.
Most of the eslint plugin projects have the rules in one folder.