### PR TITLE
Update link to ESLint provided formatters (Fixes #239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ gulp.src(['**/*.js','!node_modules/**'])
 
 Format all linted files once. This should be used in the stream after piping through `eslint`; otherwise, this will find no ESLint results to format.
 
-The `formatter` argument may be a `String`, `Function`, or `undefined`. As a `String`, a formatter module by that name or path will be resolved as a module, relative to `process.cwd()`, or as one of the [ESLint-provided formatters](https://github.com/eslint/eslint/tree/master/lib/formatters). If `undefined`, the ESLint “stylish” formatter will be resolved. A `Function` will be called with an `Array` of file linting results to format.
+The `formatter` argument may be a `String`, `Function`, or `undefined`. As a `String`, a formatter module by that name or path will be resolved as a module, relative to `process.cwd()`, or as one of the [ESLint-provided formatters](https://github.com/eslint/eslint/tree/master/lib/cli-engine/formatters). If `undefined`, the ESLint “stylish” formatter will be resolved. A `Function` will be called with an `Array` of file linting results to format.
 
 ```javascript
 // use the default "stylish" ESLint formatter


### PR DESCRIPTION
- ESLint 6.x moved the formatters to cli-engine folder (see [commit](https://github.com/eslint/eslint/commit/219aecb78bc646d44bad27dc775a9b3d3dc58232))